### PR TITLE
include subscription_key on previewFinalData and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ See differences between final and tariff line data at the [Docs](https://uncomtr
 ## Examples of python usage
 - Extract Australia imports of commodity code 91 in classic mode in May 2022
 ``` python
-mydf = comtradeapicall.previewFinalData(typeCode='C', freqCode='M', clCode='HS', period='202205',
+mydf = comtradeapicall.previewFinalData(subscription_key, typeCode='C', freqCode='M', clCode='HS', period='202205',
                                         reporterCode='36', cmdCode='91', flowCode='M', partnerCode=None,
                                         partner2Code=None,
                                         customsCode=None, motCode=None, maxRecords=500, format_output='JSON',
@@ -130,7 +130,7 @@ mydf = comtradeapicall.previewFinalData(typeCode='C', freqCode='M', clCode='HS',
 ```    
 - Extract Australia tariff line imports of commodity code started with 90 and 91 from Indonesia in May 2022
 ``` python
-mydf = comtradeapicall.previewTarifflineData(typeCode='C', freqCode='M', clCode='HS', period='202205',
+mydf = comtradeapicall.previewTarifflineData(subscription_key, typeCode='C', freqCode='M', clCode='HS', period='202205',
                                              reporterCode='36', cmdCode='91,90', flowCode='M', partnerCode=36,
                                              partner2Code=None,
                                              customsCode=None, motCode=None, maxRecords=500, format_output='JSON',

--- a/src/comtradeapicall/PreviewGet.py
+++ b/src/comtradeapicall/PreviewGet.py
@@ -59,11 +59,11 @@ def getPreviewData(subscription_key, tradeDataType, typeCode, freqCode, clCode, 
             print(f'Request error: {err}')
 
 
-def previewFinalData(typeCode, freqCode, clCode, period, reporterCode, cmdCode, flowCode,
+def previewFinalData(subscription_key, typeCode, freqCode, clCode, period, reporterCode, cmdCode, flowCode,
                      partnerCode,
                      partner2Code, customsCode, motCode, maxRecords=None, format_output=None,
                      aggregateBy=None, breakdownMode=None, countOnly=None, includeDesc=None, proxy_url=None):
-    return getPreviewData(None, 'FINAL', typeCode, freqCode, clCode, period, reporterCode,
+    return getPreviewData(subscription_key, 'FINAL', typeCode, freqCode, clCode, period, reporterCode,
                           cmdCode, flowCode,
                           partnerCode,
                           partner2Code, customsCode, motCode, maxRecords, format_output, aggregateBy,
@@ -71,14 +71,14 @@ def previewFinalData(typeCode, freqCode, clCode, period, reporterCode, cmdCode, 
                           countOnly, includeDesc, proxy_url)
 
 
-def _previewFinalData(typeCode, freqCode, clCode, period, reporterCode, cmdCode, flowCode,
+def _previewFinalData(subscription_key, typeCode, freqCode, clCode, period, reporterCode, cmdCode, flowCode,
                       partnerCode,
                       partner2Code, customsCode, motCode, maxRecords=None, format_output=None,
                       aggregateBy=None, breakdownMode=None, countOnly=None, includeDesc=None, proxy_url=None):
     main_df = pandas.DataFrame()
     for single_period in list(period.split(",")):
         try:
-            staging_df = previewFinalData(typeCode, freqCode, clCode, single_period, reporterCode, cmdCode, flowCode,
+            staging_df = previewFinalData(subscription_key, typeCode, freqCode, clCode, single_period, reporterCode, cmdCode, flowCode,
                                           partnerCode,
                                           partner2Code, customsCode, motCode, maxRecords, format_output, aggregateBy,
                                           breakdownMode,
@@ -86,7 +86,7 @@ def _previewFinalData(typeCode, freqCode, clCode, period, reporterCode, cmdCode,
         except:  # retry once more after 10 secs  # noqa: E722
             print('Repeating API call for period: ' + single_period)
             t.sleep(10)
-            staging_df = previewFinalData(typeCode, freqCode, clCode, single_period, reporterCode, cmdCode, flowCode,
+            staging_df = previewFinalData(subscription_key, typeCode, freqCode, clCode, single_period, reporterCode, cmdCode, flowCode,
                                           partnerCode,
                                           partner2Code, customsCode, motCode, maxRecords, format_output, aggregateBy,
                                           breakdownMode,
@@ -95,11 +95,11 @@ def _previewFinalData(typeCode, freqCode, clCode, period, reporterCode, cmdCode,
     return main_df
 
 
-def previewTarifflineData(typeCode, freqCode, clCode, period, reporterCode, cmdCode, flowCode,
+def previewTarifflineData(subscription_key, typeCode, freqCode, clCode, period, reporterCode, cmdCode, flowCode,
                           partnerCode,
                           partner2Code, customsCode, motCode, maxRecords=None, format_output=None,
                           countOnly=None, includeDesc=None, proxy_url=None):
-    return getPreviewData(None, 'TARIFFLINE', typeCode, freqCode, clCode, period, reporterCode,
+    return getPreviewData(subscription_key, 'TARIFFLINE', typeCode, freqCode, clCode, period, reporterCode,
                           cmdCode, flowCode,
                           partnerCode,
                           partner2Code, customsCode, motCode, maxRecords, format_output, None,
@@ -107,14 +107,14 @@ def previewTarifflineData(typeCode, freqCode, clCode, period, reporterCode, cmdC
                           countOnly, includeDesc, proxy_url)
 
 
-def _previewTarifflineData(typeCode, freqCode, clCode, period, reporterCode, cmdCode, flowCode,
+def _previewTarifflineData(subscription_key, typeCode, freqCode, clCode, period, reporterCode, cmdCode, flowCode,
                            partnerCode,
                            partner2Code, customsCode, motCode, maxRecords=None, format_output=None,
                            countOnly=None, includeDesc=None, proxy_url=None):
     main_df = pandas.DataFrame()
     for single_period in list(period.split(",")):
         try:
-            staging_df = previewTarifflineData(typeCode, freqCode, clCode, single_period, reporterCode, cmdCode,
+            staging_df = previewTarifflineData(subscription_key, typeCode, freqCode, clCode, single_period, reporterCode, cmdCode,
                                                flowCode,
                                                partnerCode,
                                                partner2Code, customsCode, motCode, maxRecords, format_output,
@@ -122,7 +122,7 @@ def _previewTarifflineData(typeCode, freqCode, clCode, period, reporterCode, cmd
         except:  # retry once more after 10 secs  # noqa: E722
             print('Repeating API call for period: ' + single_period)
             t.sleep(10)
-            staging_df = previewTarifflineData(typeCode, freqCode, clCode, single_period, reporterCode, cmdCode, flowCode,
+            staging_df = previewTarifflineData(subscription_key, typeCode, freqCode, clCode, single_period, reporterCode, cmdCode, flowCode,
                                                partnerCode,
                                                partner2Code, customsCode, motCode, maxRecords, format_output,
                                                countOnly, includeDesc)

--- a/tests/example calling functions - script.py
+++ b/tests/example calling functions - script.py
@@ -19,21 +19,21 @@ lastweek = today - timedelta(days=7)
 
 # Call preview final data API to a data frame, max to 500 records, no subscription key required
 # This example: Australia imports of commodity code 91 in classic mode in May 2022
-mydf = comtradeapicall.previewFinalData(typeCode='C', freqCode='M', clCode='HS', period='202205',
+mydf = comtradeapicall.previewFinalData(subscription_key, typeCode='C', freqCode='M', clCode='HS', period='202205',
                                         reporterCode='36', cmdCode='91', flowCode='M', partnerCode=None,
                                         partner2Code=None,
                                         customsCode=None, motCode=None, maxRecords=500, format_output='JSON',
                                         aggregateBy=None, breakdownMode='classic', countOnly=None, includeDesc=True)
 print(mydf.head(5))
 # The same preview final call but using proxy_url
-mydf = comtradeapicall.previewFinalData(typeCode='C', freqCode='M', clCode='HS', period='202205',
+mydf = comtradeapicall.previewFinalData(subscription_key, typeCode='C', freqCode='M', clCode='HS', period='202205',
                                         reporterCode='36', cmdCode='91', flowCode='M', partnerCode=None,
                                         partner2Code=None,
                                         customsCode=None, motCode=None, maxRecords=500, format_output='JSON',
                                         aggregateBy=None, breakdownMode='classic', countOnly=None, includeDesc=True, proxy_url=proxy_url)
 print(mydf.head(5))
 # This function will split the query into multiple API calls for optimization (and avoiding timeout)
-mydf = comtradeapicall._previewFinalData(typeCode='C', freqCode='M', clCode='HS', period='202105,202205',
+mydf = comtradeapicall._previewFinalData(subscription_key, typeCode='C', freqCode='M', clCode='HS', period='202105,202205',
                                          reporterCode='36', cmdCode='91', flowCode='M', partnerCode=None,
                                          partner2Code=None,
                                          customsCode=None, motCode=None, maxRecords=500, format_output='JSON',
@@ -42,14 +42,14 @@ print(mydf.head(5))
 
 # Call preview tariffline data API to a data frame, max to 500 records, no subscription key required
 # This example: Australia imports of commodity code started with 90 and 91 from Indonesia in May 2022
-mydf = comtradeapicall.previewTarifflineData(typeCode='C', freqCode='M', clCode='HS', period='202205',
+mydf = comtradeapicall.previewTarifflineData(subscription_key, typeCode='C', freqCode='M', clCode='HS', period='202205',
                                              reporterCode='36', cmdCode='91,90', flowCode='M', partnerCode=360,
                                              partner2Code=None,
                                              customsCode=None, motCode=None, maxRecords=500, format_output='JSON',
                                              countOnly=None, includeDesc=True)
 print(mydf.head(5))
 # This function will split the query into multiple API calls for optimization (and avoiding timeout)
-mydf = comtradeapicall._previewTarifflineData(typeCode='C', freqCode='M', clCode='HS', period='202105,202205',
+mydf = comtradeapicall._previewTarifflineData(subscription_key, typeCode='C', freqCode='M', clCode='HS', period='202105,202205',
                                               reporterCode='36', cmdCode='91,90', flowCode='M', partnerCode=360,
                                               partner2Code=None,
                                               customsCode=None, motCode=None, maxRecords=500, format_output='JSON',
@@ -204,7 +204,7 @@ print(len(mydf))
 country_code = comtradeapicall.convertCountryIso3ToCode('USA,FRA,CHE,ITA')
 print(country_code)
 # use the convert function country_code in preview call
-mydf = comtradeapicall.previewFinalData(typeCode='C', freqCode='M', clCode='HS', period='202205',
+mydf = comtradeapicall.previewFinalData(subscription_key, typeCode='C', freqCode='M', clCode='HS', period='202205',
                                         reporterCode=comtradeapicall.convertCountryIso3ToCode('USA,FRA,CHE,ITA'), cmdCode='91', flowCode='M', partnerCode=None,
                                         partner2Code=None, customsCode=None, motCode=None)
 print(mydf.head(5))


### PR DESCRIPTION
The COMTRADE API calls now need the subscription_key for preview functions, else it returns an error message ("All calls are rejected by policy.")

More precisely, this patch fixes the functions:
- comtradeapicall.previewFinalData
- comtradeapicall.previewTarifflineData

so that they now take subscription_key as an input, because else they will return an error.